### PR TITLE
Move microg settings to main settings page

### DIFF
--- a/play-services-core/src/main/AndroidManifest.xml
+++ b/play-services-core/src/main/AndroidManifest.xml
@@ -447,9 +447,10 @@
             android:label="@string/gms_settings_name"
             android:theme="@style/Theme.AppCompat.Settings.Dashboard">
             <intent-filter>
-                <action android:name="com.android.settings.action.EXTRA_SETTINGS"/>
+                <action android:name="com.android.settings.action.IA_SETTINGS"/>
+                <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
-            <meta-data android:name="com.android.settings.category" android:value="com.android.settings.category.device"/>
+            <meta-data android:name="com.android.settings.category" android:value="com.android.settings.category.ia.homepage"/>
             <meta-data android:name="com.android.settings.icon" android:resource="@drawable/microg_light_color_24"/>
             <meta-data android:name="com.android.settings.summary" android:resource="@string/gms_settings_summary"/>
         </activity-alias>

--- a/play-services-core/src/main/res/values-ru/strings.xml
+++ b/play-services-core/src/main/res/values-ru/strings.xml
@@ -16,8 +16,8 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="gms_app_name">microG Services Core</string>
-    <string name="gms_settings_name">Настройки MicroG</string>
-    <string name="gms_settings_summary">Конфигурирование сервисов microG.</string>
+    <string name="gms_settings_name">Настройки microG</string>
+    <string name="gms_settings_summary">Конфигурирование сервисов microG</string>
 
     <string name="just_a_sec">Пожалуйста, подождите...</string>
     <string name="google_account_label">Google</string>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -16,8 +16,8 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="gms_app_name">microG Services Core</string>
-    <string name="gms_settings_name">microG Settings</string>
-    <string name="gms_settings_summary">Setup microG services Core.</string>
+    <string name="gms_settings_name">MicroG Settings</string>
+    <string name="gms_settings_summary">Setup microG services Core</string>
 
     <string name="just_a_sec">Just a sec…</string>
     <string name="google_account_label">Google</string>

--- a/play-services-core/src/main/res/values/strings.xml
+++ b/play-services-core/src/main/res/values/strings.xml
@@ -16,8 +16,8 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="gms_app_name">microG Services Core</string>
-    <string name="gms_settings_name">MicroG Settings</string>
-    <string name="gms_settings_summary">Setup microG services Core</string>
+    <string name="gms_settings_name">MicroG settings</string>
+    <string name="gms_settings_summary">Setup microG services core</string>
 
     <string name="just_a_sec">Just a sec…</string>
     <string name="google_account_label">Google</string>


### PR DESCRIPTION
I don't know why I have not done this way before. 
I checked Google gmscore apks, this should work on android 6+

That how it looks on my android 8.1

![Screenshot_20190319-054531_Settings](https://user-images.githubusercontent.com/31875619/54577111-99fb7500-4a0b-11e9-9248-82458f8dc4fb.png)

Will you be so kind to test it?
This is default google gmscore way.